### PR TITLE
Added endpoint to import one conference

### DIFF
--- a/src/main/java/com/github/peggybrown/speechrank/ConferencesRepository.java
+++ b/src/main/java/com/github/peggybrown/speechrank/ConferencesRepository.java
@@ -1,7 +1,9 @@
 package com.github.peggybrown.speechrank;
 
+import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.github.peggybrown.speechrank.dto.ConferenceImportDto;
 import javaslang.collection.List;
 
 import lombok.extern.java.Log;
@@ -30,17 +32,17 @@ public class ConferencesRepository {
     public void add(Rate rate) {
         log.info("Rate added: " + rate.toString());
         Presentation presentation = conferences
-                .flatMap(Conference::getPresentations)
-                .find(prez -> prez.getId().equals(rate.getPresentationId())).get();
+            .flatMap(Conference::getPresentations)
+            .find(prez -> prez.getId().equals(rate.getPresentationId())).get();
         presentation.addRate(rate);
     }
 
     public void add(Comment comment) {
         log.info("Comment added: " + comment.toString());
         conferences
-                .flatMap(Conference::getPresentations)
-                .find(prez -> prez.getId().equals(comment.getPresentationId()))
-                .map(prez -> prez.addComment(comment));
+            .flatMap(Conference::getPresentations)
+            .find(prez -> prez.getId().equals(comment.getPresentationId()))
+            .map(prez -> prez.addComment(comment));
 
     }
 
@@ -48,7 +50,7 @@ public class ConferencesRepository {
         log.info("Conference added: " + conf.toString());
         conferences = conferences.append(conf);
         years.filter(y -> y.getYear().equals(year))
-                .map(y -> y.addConference(conf));
+            .map(y -> y.addConference(conf));
     }
 
     public java.util.List<Conference> getConferences() {
@@ -76,4 +78,8 @@ public class ConferencesRepository {
         years = List.of(new Year("2014"), new Year("2015"));
     }
 
+    public void importConference(ConferenceImportDto conf) {
+        Conference conference = new Conference(UUID.randomUUID().toString(), conf.getName(), importer.importFromYouTubePlaylist(conf.getPlaylistLink()).map(Presentation::new));
+        add(conf.getYear(), conference);
+    }
 }

--- a/src/main/java/com/github/peggybrown/speechrank/delivery/rest/RatpackRestServer.java
+++ b/src/main/java/com/github/peggybrown/speechrank/delivery/rest/RatpackRestServer.java
@@ -1,6 +1,7 @@
 package com.github.peggybrown.speechrank.delivery.rest;
 
 import com.github.peggybrown.speechrank.ConferencesRepository;
+import com.github.peggybrown.speechrank.dto.ConferenceImportDto;
 import com.github.peggybrown.speechrank.entity.Comment;
 import com.github.peggybrown.speechrank.entity.Rate;
 import ratpack.server.RatpackServer;
@@ -18,29 +19,31 @@ public class RatpackRestServer {
     }
 
     public void start() throws Exception {
+        conferencesRepo.importAllConferences();
         RatpackServer.start(server -> server
-                .handlers(chain -> chain
-                        .all(new CORSHandler())
-                        .get("", ctx -> ctx.render(options))
-                        .post("api/rating", ctx ->
-                                ctx.parse(Rate.class).then(rate -> {
-                                    conferencesRepo.add(rate);
-                                    ctx.render(json(rate.getRate()));
-                                }))
-                        .post("api/comment", ctx ->
-                                ctx.parse(Comment.class).then(comment -> {
-                                    conferencesRepo.add(comment);
-                                    ctx.render(json(comment.getComment()));
-                                }))
-                        .post("api/import", ctx -> {
-                            conferencesRepo.importAllConferences();
-                            ctx.render("OK");
-                        })
-                        .get("api/conferences", ctx -> ctx.render(json(conferencesRepo.getYears())))
-                        .get("api/conference/:id", ctx -> {
-                            ctx.render(json(conferencesRepo.getConference(ctx.getPathTokens().get("id"))));
-                        })
-                ));
+            .handlers(chain -> chain
+                .all(new CORSHandler())
+                .get("", ctx -> ctx.render(options))
+                .post("api/rating", ctx ->
+                    ctx.parse(Rate.class).then(rate -> {
+                        conferencesRepo.add(rate);
+                        ctx.render(json(rate.getRate()));
+                    }))
+                .post("api/comment", ctx ->
+                    ctx.parse(Comment.class).then(comment -> {
+                        conferencesRepo.add(comment);
+                        ctx.render(json(comment.getComment()));
+                    }))
+                .post("api/import", ctx ->
+                    ctx.parse(ConferenceImportDto.class).then(conf -> {
+                        conferencesRepo.importConference(conf);
+                        ctx.render(json(conf));
+                    }))
+                .get("api/conferences", ctx -> ctx.render(json(conferencesRepo.getYears())))
+                .get("api/conference/:id", ctx -> {
+                    ctx.render(json(conferencesRepo.getConference(ctx.getPathTokens().get("id"))));
+                })
+            ));
     }
 
 }

--- a/src/main/java/com/github/peggybrown/speechrank/dto/ConferenceImportDto.java
+++ b/src/main/java/com/github/peggybrown/speechrank/dto/ConferenceImportDto.java
@@ -1,0 +1,10 @@
+package com.github.peggybrown.speechrank.dto;
+
+import lombok.Data;
+
+@Data
+public class ConferenceImportDto {
+    String year;
+    String name;
+    String playlistLink;
+}

--- a/src/main/java/com/github/peggybrown/speechrank/gateway/Importer.java
+++ b/src/main/java/com/github/peggybrown/speechrank/gateway/Importer.java
@@ -42,7 +42,7 @@ public class Importer {
     public static final JsonFactory JSON_FACTORY = new JacksonFactory();
 
 
-    private javaslang.collection.List<VideoData> importFromYouTubePlaylist(String playlistId) {
+    public javaslang.collection.List<VideoData> importFromYouTubePlaylist(String playlistId) {
         javaslang.collection.List<VideoData> videos = javaslang.collection.List.empty();
         try {
             // This object is used to make YouTube Data API requests. The last


### PR DESCRIPTION
4 conferences are imported immediately now.
Additional conferences can be added using POST with name, year and playlistLink.
